### PR TITLE
Add download csv module

### DIFF
--- a/app/services/download_csv.rb
+++ b/app/services/download_csv.rb
@@ -8,7 +8,7 @@ module DownloadCsv
       format.html { render_template }
       format.json { render json: @items }
       format.csv do
-        send_data csv_responder(data, collation)
+        send_data csv_responder(data)
       end
     end
   end

--- a/app/services/download_csv.rb
+++ b/app/services/download_csv.rb
@@ -1,0 +1,21 @@
+module DownloadCsv
+
+  def index_for_csv(data)
+    authorize! :read, model_class
+    list_breadcrumbs
+    @items = index_items
+    respond_to do |format|
+      format.html { render_template }
+      format.json { render json: @items }
+      format.csv do
+        send_data csv_responder(data, collation)
+      end
+    end
+  end
+
+  protected
+
+  def csv_responder(data)
+    data.to_csv
+  end
+end

--- a/app/services/download_csv.rb
+++ b/app/services/download_csv.rb
@@ -1,5 +1,5 @@
+# Allows quickly rewrite admin controller's index action for csv downloading
 module DownloadCsv
-
   def index_for_csv(data)
     authorize! :read, model_class
     list_breadcrumbs


### PR DESCRIPTION
This module allows to rewrite quickly admin controller index action for csv downloading.
Example:
```ruby
include DownloadCsv

def index
  data = UserCsvService.new(::User.all)
  index_for_csv(data)
end

# For custom implementation
def csv_responder(data)
 # rewrite
end
```