### PR TITLE
Fix default table order field

### DIFF
--- a/app/services/search/conditions/abstract.rb
+++ b/app/services/search/conditions/abstract.rb
@@ -40,7 +40,7 @@ module RademadeAdmin
 
         def order
           order_conditions = RademadeAdmin::Search::Part::Order.new
-          order_conditions.add(:id, :desc)
+          order_conditions.add(@data_items.primary_field.name, :desc)
           order_conditions
         end
 


### PR DESCRIPTION
Rademade_admin orders items by :id field by default, but when this field does not exists - it fails. (in case primary field changed manually) 