### PR TITLE
Make rademade_admin get along with md files

### DIFF
--- a/lib/rademade_admin/engine.rb
+++ b/lib/rademade_admin/engine.rb
@@ -12,7 +12,22 @@ module RademadeAdmin
     config.assets.paths << "#{config.root}/vendor/assets/javascript/bower_components"
 
     initializer 'ckeditor.assets_precompile', :group => :all do |app|
-      app.config.assets.precompile += %w(rademade_admin.css rademade_admin.js ckeditor/* rademade_admin/fav1.ico)
+      filter_ckeditor_assets = Proc.new do |logical_path|
+        File.fnmatch('ckeditor/*', logical_path) \
+          && ! [
+            'ckeditor/CHANGES',
+            'ckeditor/LICENSE',
+            'ckeditor/README',
+            'ckeditor/plugins/scayt/CHANGELOG',
+            'ckeditor/plugins/scayt/LICENSE',
+            'ckeditor/plugins/scayt/README',
+            'ckeditor/plugins/wsc/LICENSE',
+            'ckeditor/plugins/wsc/README',
+            'ckeditor/skins/moono/readme',
+          ].include?(logical_path)
+      end
+      app.config.assets.precompile << filter_ckeditor_assets
+      app.config.assets.precompile += %w(rademade_admin.css rademade_admin.js rademade_admin/fav1.ico)
     end
 
     $LOAD_PATH << "#{config.root}/app/services/"


### PR DESCRIPTION
`angular-rails-templates` [registers][1] in `sprockets` any template engine it can from the list: erb haml liquid md radius slim str textile wiki. `apitome` comes with template engine for md files. It must be poorly written, since `sprockets` chokes on `ckeditor`'s `CHANGES.md` file (and others) as a result. Namely it [fails][2] to add extension back to the filename. But I didn't dig into it enough to be certain who's the culprit.

[1]: https://github.com/pitr/angular-rails-templates/blob/v1.0.2/lib/angular-rails-templates/engine.rb#L12-L21
[2]: https://github.com/rails/sprockets/blob/v2.12.4/lib/sprockets/asset_attributes.rb#L50